### PR TITLE
Convert exporter to use batch, update for EDD 3.0 compatibility

### DIFF
--- a/edd-discount-code-generator.php
+++ b/edd-discount-code-generator.php
@@ -58,13 +58,17 @@ if( !class_exists( 'eddDev7DiscountCodeGenerator' ) ){
 			return $pages;
 	    }
 
+		/**
+		 * Adds the discount code exporter to the Reports > Export screen.
+		 *
+		 * @return void
+		 */
 		public function edd_add_code_export() {
-		?>
-		<div class="postbox">
-			<h3><?php esc_html_e( 'Export Discount Codes in CSV', 'edd_dcg' ); ?></h3>
-			<div class="inside">
-				<p><?php esc_html_e( 'Download a CSV of all discount codes.', 'edd_dcg' ); ?></p>
-				<p>
+			?>
+			<div class="postbox">
+				<h3><?php esc_html_e( 'Export Discount Codes in CSV', 'edd_dcg' ); ?></h3>
+				<div class="inside">
+					<p><?php esc_html_e( 'Download a CSV of all discount codes.', 'edd_dcg' ); ?></p>
 					<form id="edd-dcg-export" method="post" class="edd-export-form edd-import-export-form">
 						<?php wp_nonce_field( 'edd_ajax_export', 'edd_ajax_export' ); ?>
 						<input type="hidden" name="edd-dcg-recent" value="<?php echo ( ! empty( $_GET['edd-dcg-recent'] ) ? (int) $_GET['edd-dcg-recent'] : '' ); ?>"/>
@@ -72,10 +76,9 @@ if( !class_exists( 'eddDev7DiscountCodeGenerator' ) ){
 						<input type="submit" value="<?php esc_html_e( 'Generate CSV', 'edd_dcg' ); ?>" class="button-secondary"/>
 						<span class="spinner"></span>
 					</form>
-				</p>
+				</div>
 			</div>
-		</div>
-		<?php
+			<?php
 		}
 	}
 	$eddDev7DiscountCodeGenerator = new eddDev7DiscountCodeGenerator();

--- a/edd-discount-code-generator.php
+++ b/edd-discount-code-generator.php
@@ -38,12 +38,11 @@ if( !class_exists( 'eddDev7DiscountCodeGenerator' ) ){
 	        add_filter('edd_load_scripts_for_these_pages', array($this, 'edd_load_scripts_for_these_pages'));
 	        add_filter('edd_load_scripts_for_discounts', array($this, 'edd_load_scripts_for_these_pages'));
 
-	        add_action('edd_reports_tab_export_content_bottom', array($this, 'edd_add_code_export'));
-	        add_action('edd_discount_codes_export', array($this, 'edd_export_all_discount_codes') );
-	        add_action('edd_discount_codes_recent_export', array($this, 'edd_export_recent_discount_codes') );
+			add_action( 'edd_reports_tab_export_content_bottom', array( $this, 'edd_add_code_export' ) );
 
-			if( is_admin() ) {
+			if ( is_admin() ) {
 
+				include_once EDD_DCG_PLUGIN_DIR . '/includes/export-functions.php';
 				include_once( EDD_DCG_PLUGIN_DIR .'/includes/admin-page.php' );
 				include_once( EDD_DCG_PLUGIN_DIR .'/includes/discount-actions.php' );
 
@@ -59,35 +58,25 @@ if( !class_exists( 'eddDev7DiscountCodeGenerator' ) ){
 			return $pages;
 	    }
 
-	    function edd_add_code_export() {
-	    ?>
-		    <div class="postbox">
-				<h3><span><?php _e('Export Discount Codes in CSV', 'edd_dcg'); ?></span></h3>
-				<div class="inside">
-					<p><?php _e( 'Download a CSV of all discount codes.', 'edd_dcg' ); ?></p>
-					<p>
-						<form method="post">
-							<input type="hidden" name="edd-action" value="discount_codes_export"/>
-							<input type="submit" value="<?php _e( 'Generate CSV', 'edd_dcg' ); ?>" class="button-secondary"/>
-						</form>
-					</p>
-				</div>
+		public function edd_add_code_export() {
+		?>
+		<div class="postbox">
+			<h3><?php esc_html_e( 'Export Discount Codes in CSV', 'edd_dcg' ); ?></h3>
+			<div class="inside">
+				<p><?php esc_html_e( 'Download a CSV of all discount codes.', 'edd_dcg' ); ?></p>
+				<p>
+					<form id="edd-dcg-export" method="post" class="edd-export-form edd-import-export-form">
+						<?php wp_nonce_field( 'edd_ajax_export', 'edd_ajax_export' ); ?>
+						<input type="hidden" name="edd-dcg-recent" value="<?php echo ( ! empty( $_GET['edd-dcg-recent'] ) ? (int) $_GET['edd-dcg-recent'] : '' ); ?>"/>
+						<input type="hidden" name="edd-export-class" value="EDD_Discount_Codes_Export"/>
+						<input type="submit" value="<?php esc_html_e( 'Generate CSV', 'edd_dcg' ); ?>" class="button-secondary"/>
+						<span class="spinner"></span>
+					</form>
+				</p>
 			</div>
+		</div>
 		<?php
-	    }
-
-		function edd_export_all_discount_codes() {
-			require_once EDD_DCG_PLUGIN_DIR . '/includes/class-export-discount-codes.php';
-			$discount_code_export = new EDD_Discount_Codes_Export();
-			$discount_code_export->export();
 		}
-
-		function edd_export_recent_discount_codes() {
-			require_once EDD_DCG_PLUGIN_DIR . '/includes/class-export-discount-codes.php';
-			$discount_code_export = new EDD_Discount_Codes_Export(true);
-			$discount_code_export->export();
-		}
-
 	}
 	$eddDev7DiscountCodeGenerator = new eddDev7DiscountCodeGenerator();
 }

--- a/includes/admin-page.php
+++ b/includes/admin-page.php
@@ -37,16 +37,17 @@ function edd_dcg_page() {
     <?php
 }
 
+/**
+ * Outputs the admin message after codes have been successfully generated.
+ *
+ * @return void
+ */
 function edd_dcg_admin_messages() {
-	$number = ! empty( $_GET['edd-number'] ) ? (int) $_GET['edd-number'] : false;
-
-	if ( ! $number || ! current_user_can( 'manage_shop_discounts' ) ) {
+	$number = edd_dcg_code_generation_was_successful();
+	if ( ! $number ) {
 		return;
 	}
 
-	if ( empty( $_GET['edd-message'] ) || 'discounts_added' !== $_GET['edd-message'] ) {
-		return;
-	}
 	ob_start();
 	printf(
 		/* translators: the number of discount codes generated. */
@@ -67,3 +68,38 @@ function edd_dcg_admin_messages() {
 	settings_errors( 'edd-dcg-notices' );
 }
 add_action( 'admin_notices', 'edd_dcg_admin_messages', 10 );
+
+/**
+ * Enqueues the export tools script in EDD 3.0.
+ *
+ * @since 1.1.1
+ * @return void
+ */
+function edd_dcg_enqueue_export_script() {
+	if ( ! edd_dcg_code_generation_was_successful() ) {
+		return;
+	}
+	wp_enqueue_script( 'edd-admin-tools-export' );
+}
+add_action( 'admin_enqueue_scripts', 'edd_dcg_enqueue_export_script' );
+
+/**
+ * Determines whether discount code generation was successful.
+ * Returns false if the current user does not have sufficient permissions.
+ *
+ * @since 1.1.1
+ * @return bool|int False if not; otherwise returns the number of codes generated.
+ */
+function edd_dcg_code_generation_was_successful() {
+	$number = ! empty( $_GET['edd-number'] ) ? (int) $_GET['edd-number'] : false;
+
+	if ( ! $number || ! current_user_can( 'manage_shop_discounts' ) ) {
+		return false;
+	}
+
+	if ( empty( $_GET['edd-message'] ) || 'discounts_added' !== $_GET['edd-message'] ) {
+		return false;
+	}
+
+	return $number;
+}

--- a/includes/admin-page.php
+++ b/includes/admin-page.php
@@ -38,14 +38,32 @@ function edd_dcg_page() {
 }
 
 function edd_dcg_admin_messages() {
-	global $edd_options;
+	$number = ! empty( $_GET['edd-number'] ) ? (int) $_GET['edd-number'] : false;
 
-	if ( isset( $_GET['edd-message'] ) && 'discounts_added' == $_GET['edd-message'] && current_user_can( 'manage_shop_discounts' ) ) {
-		 $url = admin_url( 'edit.php?post_type=download&edd-action=discount_codes_recent_export' );
-		 $message = $_GET['edd-number'] .' '. __( 'codes generated', 'edd_dcg' ) .'. <a href="'. $url .'">'. __( 'Export to CSV', 'edd_dcg' ) .'</a>';
-		 add_settings_error( 'edd-dcg-notices', 'edd-discounts-added', $message, 'updated' );
-		 settings_errors( 'edd-dcg-notices' );
+	if ( ! $number || ! current_user_can( 'manage_shop_discounts' ) ) {
+		return;
 	}
 
+	if ( empty( $_GET['edd-message'] ) || 'discounts_added' !== $_GET['edd-message'] ) {
+		return;
+	}
+	ob_start();
+	printf(
+		/* translators: the number of discount codes generated. */
+		esc_html__( '%s codes generated.', 'edd_dcg' ),
+		(int) $number
+	);
+	?>
+	<form id="edd-dcg-export" method="post" class="edd-export-form edd-import-export-form">
+		<?php wp_nonce_field( 'edd_ajax_export', 'edd_ajax_export' ); ?>
+		<input type="hidden" name="edd-dcg-recent" value="<?php echo ( (int) $number ); ?>"/>
+		<input type="hidden" name="edd-export-class" value="EDD_Discount_Codes_Export"/>
+		<input type="submit" value="<?php esc_html_e( 'Generate CSV', 'edd_dcg' ); ?>" class="button-secondary"/>
+		<span class="spinner"></span>
+	</form>
+	<?php
+	$message = ob_get_clean();
+	add_settings_error( 'edd-dcg-notices', 'edd-discounts-added', $message, 'updated' );
+	settings_errors( 'edd-dcg-notices' );
 }
 add_action( 'admin_notices', 'edd_dcg_admin_messages', 10 );

--- a/includes/class-export-discount-codes.php
+++ b/includes/class-export-discount-codes.php
@@ -7,103 +7,151 @@
  */
 
 // Exit if accessed directly
-if ( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
+class EDD_Discount_Codes_Export extends EDD_Batch_Export {
 
-class EDD_Discount_Codes_Export extends EDD_Export {
+	/**
+	 * Whether the export should include just the most recently generated discount codes.
+	 *
+	 * @var boolean
+	 */
+	private $recent = false;
 
-	private $recent;
+	/**
+	 * The export type.
+	 *
+	 * @var string
+	 */
 	public $export_type = 'discount_codes';
 
-	function __construct($recent = false) {
-		$this->recent = $recent;
-	}
-
+	/**
+	 * The columns for the CSV.
+	 *
+	 * @return array
+	 */
 	public function csv_cols() {
-		$cols = array(
-			'name'  	=> __( 'Name', 'edd_dcg' ),
-			'code'  	=> __( 'Code', 'edd_dcg' ),
-			'amount'  	=> __( 'Amount', 'edd_dcg' ),
-			'uses'  	=> __( 'Uses', 'edd_dcg' ),
-			'max_uses' 	=> __( 'Max Uses', 'edd_dcg' ),
-			'start_date'=> __( 'Start Date', 'edd_dcg' ),
-			'expiration'=> __( 'Expiration', 'edd_dcg' ),
-			'status'  	=> __( 'Status', 'edd_dcg' ),
+		return array(
+			'name'       => __( 'Name', 'edd_dcg' ),
+			'code'       => __( 'Code', 'edd_dcg' ),
+			'amount'     => __( 'Amount', 'edd_dcg' ),
+			'uses'       => __( 'Uses', 'edd_dcg' ),
+			'max_uses'   => __( 'Max Uses', 'edd_dcg' ),
+			'start_date' => __( 'Start Date', 'edd_dcg' ),
+			'expiration' => __( 'Expiration', 'edd_dcg' ),
+			'status'     => __( 'Status', 'edd_dcg' ),
 		);
-
-		return $cols;
 	}
 
+	/**
+	 * The data for the CSV.
+	 *
+	 * @return array
+	 */
 	public function get_data() {
 
-		$discount_codes_data = array();
-		$number = -1;
-		$args = array( 	'orderby'          => 'ID',
-						'order'            => 'DESC',
-						'posts_per_page' => $number
-					);
+		$data      = array();
+		$args      = array(
+			'orderby'        => 'ID',
+			'order'          => 'DESC',
+			'paged'          => $this->step,
+			'posts_per_page' => 100,
+		);
 		$discounts = edd_get_discounts( $args );
-		if ($this->recent) {
-			$number = 1;
-			$last = edd_get_discounts( $args );
-			$code_name = $last[0]->post_name;
-			$code_name = substr($code_name, 0, strpos($code_name, '-') + 1);
-			$last_discounts = array();
+		if ( $this->recent ) {
+			$args['posts_per_page'] = $this->recent;
+			$last                   = edd_get_discounts( $args );
+			$code_name              = $last[0]->post_name;
+			$code_name              = substr( $code_name, 0, strpos( $code_name, '-' ) + 1 );
+			$last_discounts         = array();
 			foreach ( $discounts as $discount ) {
-				if ( strpos($discount->post_name, $code_name) !== false ) {
+				if ( strpos( $discount->post_name, $code_name ) !== false ) {
 					$last_discounts[] = $discount;
 				}
 			}
 			$discounts = $last_discounts;
 		}
 
-		if ( $discounts ) {
-			foreach ( $discounts as $discount ) {
-				if ( edd_get_discount_max_uses( $discount->ID ) ) {
-					$uses =  edd_get_discount_uses( $discount->ID ) . '/' . edd_get_discount_max_uses( $discount->ID );
-				} else {
-					$uses = edd_get_discount_uses( $discount->ID );
-				}
-
-				if ( edd_get_discount_max_uses( $discount->ID ) ) {
-					$max_uses = edd_get_discount_max_uses( $discount->ID ) ? edd_get_discount_max_uses( $discount->ID ) : __( 'unlimited', 'edd_dcg' );
-				} else {
-					$max_uses = __( 'Unlimited', 'edd_dcg' );
-				}
-
-				$start_date = edd_get_discount_start_date( $discount->ID );
-
-				if ( ! empty( $start_date ) ) {
-					$discount_start_date =  date_i18n( get_option( 'date_format' ), strtotime( $start_date ) );
-				} else {
-					$discount_start_date = __( 'No start date', 'edd_dcg' );
-				}
-
-				if ( edd_get_discount_expiration( $discount->ID ) ) {
-					$expiration = edd_is_discount_expired( $discount->ID ) ? __( 'Expired', 'edd_dcg' ) : date_i18n( get_option( 'date_format' ), strtotime( edd_get_discount_expiration( $discount->ID ) ) );
-				} else {
-					$expiration = __( 'No expiration', 'edd_dcg' );
-				}
-
-				$discount_codes_data[] = array(
-					'ID' 			=> $discount->ID,
-					'name' 			=> get_the_title( $discount->ID ),
-					'code' 			=> edd_get_discount_code( $discount->ID ),
-					'amount' 		=> edd_format_discount_rate( edd_get_discount_type( $discount->ID ), edd_get_discount_amount( $discount->ID ) ),
-					'uses' 			=> $uses,
-					'max_uses' 		=> $max_uses,
-					'start_date' 	=> $discount_start_date,
-					'expiration'	=> $expiration,
-					'status'		=> ucwords( $discount->post_status ),
-				);
+		if ( ! $discounts ) {
+			return false;
+		}
+		foreach ( $discounts as $discount ) {
+			if ( edd_get_discount_max_uses( $discount->ID ) ) {
+				$uses = edd_get_discount_uses( $discount->ID ) . '/' . edd_get_discount_max_uses( $discount->ID );
+			} else {
+				$uses = edd_get_discount_uses( $discount->ID );
 			}
+
+			$max_uses = __( 'Unlimited', 'edd_dcg' );
+			if ( edd_get_discount_max_uses( $discount->ID ) ) {
+				$max_uses = edd_get_discount_max_uses( $discount->ID ) ? edd_get_discount_max_uses( $discount->ID ) : __( 'unlimited', 'edd_dcg' );
+			}
+
+			$start_date          = edd_get_discount_start_date( $discount->ID );
+			$discount_start_date = __( 'No start date', 'edd_dcg' );
+			if ( ! empty( $start_date ) ) {
+				$discount_start_date = date_i18n( get_option( 'date_format' ), strtotime( $start_date ) );
+			}
+
+			$expiration = __( 'No expiration', 'edd_dcg' );
+			if ( edd_get_discount_expiration( $discount->ID ) ) {
+				$expiration = edd_is_discount_expired( $discount->ID ) ? __( 'Expired', 'edd_dcg' ) : date_i18n( get_option( 'date_format' ), strtotime( edd_get_discount_expiration( $discount->ID ) ) );
+			}
+
+			$data[] = array(
+				'ID'         => $discount->ID,
+				'name'       => get_the_title( $discount->ID ),
+				'code'       => edd_get_discount_code( $discount->ID ),
+				'amount'     => edd_format_discount_rate( edd_get_discount_type( $discount->ID ), edd_get_discount_amount( $discount->ID ) ),
+				'uses'       => $uses,
+				'max_uses'   => $max_uses,
+				'start_date' => $discount_start_date,
+				'expiration' => $expiration,
+				'status'     => ucwords( $discount->post_status ),
+			);
 		}
 
-		$data = apply_filters( 'edd_export_get_data', $discount_codes_data );
-		$data = apply_filters( 'edd_export_get_data_' . $this->export_type, $discount_codes_data );
+		$data = apply_filters( 'edd_export_get_data', $data );
+		$data = apply_filters( 'edd_export_get_data_' . $this->export_type, $data );
 
-
-		return $discount_codes_data;
+		return $data;
 	}
 
+	/**
+	 * Gets the percentage of the completed job.
+	 *
+	 * @return void
+	 */
+	public function get_percentage_complete() {
+
+		$percentage = 100;
+		if ( $this->recent ) {
+			return $percentage;
+		}
+		$discounts = edd_get_discounts(
+			array(
+				'posts_per_page' => 999999,
+				'fields'         => 'ids',
+			)
+		);
+		$total     = count( $discounts );
+
+		if ( $total > 0 ) {
+			$percentage = ( ( 100 * $this->step ) / $total ) * 100;
+		}
+
+		if ( $percentage > 100 ) {
+			$percentage = 100;
+		}
+
+		return $percentage;
+	}
+
+	public function set_properties( $request ) {
+		if ( ! empty( $request['edd-dcg-recent'] ) ) {
+			$this->recent = (int) $request['edd-dcg-recent'];
+		}
+	}
 }

--- a/includes/export-functions.php
+++ b/includes/export-functions.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Registers the discount codes batch exporter.
+ *
+ * @since 1.1.1
+ * @return void
+ */
+function edd_dcg_register_discount_batch_export() {
+	add_action( 'edd_batch_export_class_include', 'edd_dcg_include_discount_batch_processor', 10, 1 );
+}
+add_action( 'edd_register_batch_exporter', 'edd_dcg_register_discount_batch_export', 10 );
+
+/**
+ * Loads the export class file.
+ *
+ * @since 1.1.1
+ * @param string $class
+ * @return void
+ */
+function edd_dcg_include_discount_batch_processor( $class ) {
+	if ( 'EDD_Discount_Codes_Export' === $class ) {
+		require_once EDD_DCG_PLUGIN_DIR . 'includes/class-export-discount-codes.php';
+	}
+}
+
+/**
+ * Runs the discount code batch exporter.
+ *
+ * @since 1.1.1
+ * @return void
+ */
+function edd_dcg_batch_exporter() {
+	$export = new EDD_Discount_Codes_Export();
+	$export->export();
+}
+add_action( 'edd_discount_codes_batch_export', 'edd_dcg_batch_exporter' );


### PR DESCRIPTION
Fixes #4, #2

Proposed changes:
1. Reworks the discount code generator to use the batch export tool instead of exporting all of the discounts in one go. Not sure what number is appropriate to run in each step.
2. For EDD 3.0, use the `edd_get_adjustments` and `edd_count_adjustments` functions.
3. In EDD 3.0, for recent codes, just export the last xx number of codes instead of doing the extra gymnastics to compare them, which maybe is still necessary in 2.x.