### PR TITLE
Add CLI command #3

### DIFF
--- a/edd-discount-code-generator.php
+++ b/edd-discount-code-generator.php
@@ -39,7 +39,11 @@ if( !class_exists( 'eddDev7DiscountCodeGenerator' ) ){
 
 			add_action( 'edd_reports_tab_export_content_bottom', array( $this, 'edd_add_code_export' ) );
 
-			if ( is_admin() ) {
+			if ( defined( 'WP_CLI' ) && WP_CLI ) {
+				require_once EDD_DCG_PLUGIN_DIR . 'includes/class-cli.php';
+			}
+
+			if ( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 
 				include_once EDD_DCG_PLUGIN_DIR . '/includes/export-functions.php';
 				include_once EDD_DCG_PLUGIN_DIR . '/includes/admin-page.php';

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -17,14 +17,14 @@ class EDD_Discount_Code_Generator_CLI extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
+	 * <name>
+	 * : The name of this discount. This will have a number appended to it ( e.g. Name-1).
+	 *
 	 * [--number=<number>]
 	 * : Number of codes to generate.
 	 * ---
 	 * default: 1
 	 * ---
-	 *
-	 * [--name=<name>]
-	 * : The name of this discount. This will have a number appended to it ( e.g. Name-1).
 	 *
 	 * [--code-type=<code_type>]
 	 * : Type of code to generate.
@@ -38,6 +38,8 @@ class EDD_Discount_Code_Generator_CLI extends WP_CLI_Command {
 	 *
 	 * [--code-limit=<code_limit>]
 	 * : Number of characters to use for the code.
+	 * ---
+	 * default: 10
 	 *
 	 * [--amount=<amount>]
 	 * : Amount for the discount. This is combined with amount-type.
@@ -50,6 +52,9 @@ class EDD_Discount_Code_Generator_CLI extends WP_CLI_Command {
 	 *   - percent
 	 *   - flat
 	 * ---
+	 *
+	 * [--products=<product_ids>]
+	 * : Comma-separated list of product IDs.
 	 *
 	 * [--start=<start>]
 	 * : The start date for the discount code. If omitted, the discount can be used on or after today.
@@ -70,7 +75,45 @@ class EDD_Discount_Code_Generator_CLI extends WP_CLI_Command {
 	 * @param array $assoc_args
 	 */
 	public function __invoke( $args, $assoc_args ) {
+		$final_args = $assoc_args;
 
+		if ( ! isset( $args[0] ) ) {
+			WP_CLI::error( esc_html__( 'A discount name is required.', 'edd_dcg' ) );
+		}
+
+		$final_args['name'] = $args[0];
+
+		// We need to convert the format of a few args.
+		$fields_to_convert = array(
+			'number'    => 'number-codes',
+			'min-price' => 'min_price',
+			'max-uses'  => 'max',
+			'once'      => 'use_once',
+		);
+		foreach ( $fields_to_convert as $cli_key => $function_key ) {
+			if ( array_key_exists( $cli_key, $assoc_args ) ) {
+				$final_args[ $function_key ] = $assoc_args[ $cli_key ];
+				unset( $final_args[ $cli_key ] );
+			}
+		}
+
+		// Convert `products` to an array.
+		if ( ! empty( $final_args['products'] ) ) {
+			$final_args['products'] = array_map( 'intval', explode( ',', $final_args['products'] ) );
+		}
+
+		WP_CLI::line( esc_html__( 'Creating discount codes...', 'edd_dcg' ) );
+
+		$result = edd_dcg_create_discount_codes( $final_args );
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( esc_html( $result->get_error_message() ) );
+		} elseif ( true === $result ) {
+			WP_CLI::success( esc_html__( 'Discounts successfully created.', 'edd_dcg' ) );
+		} else {
+			// We should never end up here.
+			WP_CLI::error( esc_html__( 'An unexpected error has occurred.', 'edd_dcg' ) );
+		}
 	}
 
 }

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -59,14 +59,20 @@ class EDD_Discount_Code_Generator_CLI extends WP_CLI_Command {
 	 * [--product-condition=<condition>]
 	 * : Condition for discount to apply to the products.
 	 * ---
-	 * default: any
+	 * default: all
 	 * options:
 	 *    - all
 	 *    - any
 	 *
-	 * [--global]
-	 * : If not set and products are specified, discounts will only apply to selected products. If set, discounts will
-	 * apply to the entire cart.
+	 * [--scope=<scope>]
+	 * : A global scope applies the discount to the entire cart. A not_global scope only applies the discount
+	 * to the specified products.
+	 * ---
+	 * default: global
+	 * options:
+	 *     - global
+	 *     - not_global
+	 * ---
 	 *
 	 * [--start=<start>]
 	 * : The start date for the discount code. If omitted, the discount can be used on or after today.
@@ -115,9 +121,9 @@ class EDD_Discount_Code_Generator_CLI extends WP_CLI_Command {
 		// Convert `products` to an array.
 		if ( ! empty( $final_args['products'] ) ) {
 			$final_args['products']   = array_map( 'intval', explode( ',', $final_args['products'] ) );
-			$final_args['not_global'] = empty( $final_args['global'] );
+			$final_args['not_global'] = ! empty( $final_args['scope'] ) && 'not_global' === $final_args['scope'];
 
-			unset( $final_args['global'] );
+			unset( $final_args['scope'] );
 		}
 
 		WP_CLI::line( esc_html__( 'Creating discount codes...', 'edd_dcg' ) );

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -56,6 +56,18 @@ class EDD_Discount_Code_Generator_CLI extends WP_CLI_Command {
 	 * [--products=<product_ids>]
 	 * : Comma-separated list of product IDs that the discounts will apply to.
 	 *
+	 * [--product-condition=<condition>]
+	 * : Condition for discount to apply to the products.
+	 * ---
+	 * default: any
+	 * options:
+	 *    - all
+	 *    - any
+	 *
+	 * [--global]
+	 * : If not set and products are specified, discounts will only apply to selected products. If set, discounts will
+	 * apply to the entire cart.
+	 *
 	 * [--start=<start>]
 	 * : The start date for the discount code. If omitted, the discount can be used on or after today.
 	 *
@@ -85,10 +97,11 @@ class EDD_Discount_Code_Generator_CLI extends WP_CLI_Command {
 
 		// We need to convert the format of a few args.
 		$fields_to_convert = array(
-			'number'    => 'number-codes',
-			'min-price' => 'min_price',
-			'max-uses'  => 'max',
-			'once'      => 'use_once',
+			'number'            => 'number-codes',
+			'min-price'         => 'min_price',
+			'max-uses'          => 'max',
+			'once'              => 'use_once',
+			'product-condition' => 'product_condition',
 		);
 		foreach ( $fields_to_convert as $cli_key => $function_key ) {
 			if ( array_key_exists( $cli_key, $assoc_args ) ) {
@@ -99,7 +112,10 @@ class EDD_Discount_Code_Generator_CLI extends WP_CLI_Command {
 
 		// Convert `products` to an array.
 		if ( ! empty( $final_args['products'] ) ) {
-			$final_args['products'] = array_map( 'intval', explode( ',', $final_args['products'] ) );
+			$final_args['products']   = array_map( 'intval', explode( ',', $final_args['products'] ) );
+			$final_args['not_global'] = empty( $final_args['global'] );
+
+			unset( $final_args['global'] );
 		}
 
 		WP_CLI::line( esc_html__( 'Creating discount codes...', 'edd_dcg' ) );

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -125,7 +125,7 @@ class EDD_Discount_Code_Generator_CLI extends WP_CLI_Command {
 		if ( is_wp_error( $result ) ) {
 			WP_CLI::error( esc_html( $result->get_error_message() ) );
 		} elseif ( true === $result ) {
-			WP_CLI::success( esc_html__( 'Discounts successfully created.', 'edd_dcg' ) );
+			WP_CLI::success( esc_html__( 'Discount codes successfully created.', 'edd_dcg' ) );
 		} else {
 			// We should never end up here.
 			WP_CLI::error( esc_html__( 'An unexpected error has occurred.', 'edd_dcg' ) );

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -125,8 +125,11 @@ class EDD_Discount_Code_Generator_CLI extends WP_CLI_Command {
 
 		if ( is_wp_error( $result ) ) {
 			WP_CLI::error( esc_html( $result->get_error_message() ) );
-		} elseif ( true === $result ) {
-			WP_CLI::success( esc_html__( 'Discount codes successfully created.', 'edd_dcg' ) );
+		} elseif ( is_numeric( $result ) ) {
+			WP_CLI::success( sprintf(
+				_n( '%d discount code successfully created.', '%d discount codes successfully created.', $result, 'edd_dcg' ),
+				$result
+			) );
 		} else {
 			// We should never end up here.
 			WP_CLI::error( esc_html__( 'An unexpected error has occurred.', 'edd_dcg' ) );

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -100,7 +100,6 @@ class EDD_Discount_Code_Generator_CLI extends WP_CLI_Command {
 			'number'            => 'number-codes',
 			'min-price'         => 'min_price',
 			'max-uses'          => 'max',
-			'once'              => 'use_once',
 			'product-condition' => 'product_condition',
 			'amount-type'       => 'type',
 		);
@@ -110,6 +109,8 @@ class EDD_Discount_Code_Generator_CLI extends WP_CLI_Command {
 				unset( $final_args[ $cli_key ] );
 			}
 		}
+
+		$final_args['use_once'] = ! empty( $assoc_args['once'] ) ? 1 : 0;
 
 		// Convert `products` to an array.
 		if ( ! empty( $final_args['products'] ) ) {

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -54,7 +54,7 @@ class EDD_Discount_Code_Generator_CLI extends WP_CLI_Command {
 	 * ---
 	 *
 	 * [--products=<product_ids>]
-	 * : Comma-separated list of product IDs.
+	 * : Comma-separated list of product IDs that the discounts will apply to.
 	 *
 	 * [--start=<start>]
 	 * : The start date for the discount code. If omitted, the discount can be used on or after today.

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -102,6 +102,7 @@ class EDD_Discount_Code_Generator_CLI extends WP_CLI_Command {
 			'max-uses'          => 'max',
 			'once'              => 'use_once',
 			'product-condition' => 'product_condition',
+			'amount-type'       => 'type',
 		);
 		foreach ( $fields_to_convert as $cli_key => $function_key ) {
 			if ( array_key_exists( $cli_key, $assoc_args ) ) {

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * CLI Integration
+ *
+ * @package   edd-discount-code-generator
+ * @copyright Copyright (c) 2021, Sandhills Development, LLC
+ * @license   GPL2+
+ * @since     1.1.1
+ */
+
+WP_CLI::add_command( 'edd generate:discounts', 'EDD_Discount_Code_Generator_CLI' );
+
+class EDD_Discount_Code_Generator_CLI extends WP_CLI_Command {
+
+	/**
+	 * Generates discount codes.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--number=<number>]
+	 * : Number of codes to generate.
+	 * ---
+	 * default: 1
+	 * ---
+	 *
+	 * [--name=<name>]
+	 * : The name of this discount. This will have a number appended to it ( e.g. Name-1).
+	 *
+	 * [--code-type=<code_type>]
+	 * : Type of code to generate.
+	 * ---
+	 * default: hash
+	 * options:
+	 *   - hash
+	 *   - letters
+	 *   - number
+	 * ---
+	 *
+	 * [--code-limit=<code_limit>]
+	 * : Number of characters to use for the code.
+	 *
+	 * [--amount=<amount>]
+	 * : Amount for the discount. This is combined with amount-type.
+	 *
+	 * [--amount-type=<amount_type>]
+	 * : Amount type for the discount.
+	 * ---
+	 * default: percent
+	 * options:
+	 *   - percent
+	 *   - flat
+	 * ---
+	 *
+	 * [--start=<start>]
+	 * : The start date for the discount code. If omitted, the discount can be used on or after today.
+	 *
+	 * [--expiration=<expiration>]
+	 * : Expiration date of the discounts. If omitted, discounts never expire.
+	 *
+	 * [--min-price=<min_price>]
+	 * : Minimum charge amount before the discount can apply.
+	 *
+	 * [--max-uses=<max_uses>]
+	 * : The maximum number of times this discount can be used. Omit for unlimited.
+	 *
+	 * [--once]
+	 * : Limits the discount to a single-use per customer.
+	 *
+	 * @param array $args
+	 * @param array $assoc_args
+	 */
+	public function __invoke( $args, $assoc_args ) {
+
+	}
+
+}

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -121,7 +121,7 @@ class EDD_Discount_Code_Generator_CLI extends WP_CLI_Command {
 		// Convert `products` to an array.
 		if ( ! empty( $final_args['products'] ) ) {
 			$final_args['products']   = array_map( 'intval', explode( ',', $final_args['products'] ) );
-			$final_args['not_global'] = ! empty( $final_args['scope'] ) && 'not_global' === $final_args['scope'];
+			$final_args['not_global'] = ! empty( $final_args['scope'] ) && 'not_global' === $final_args['scope'] ? 1 : 0;
 
 			unset( $final_args['scope'] );
 		}

--- a/includes/discount-actions.php
+++ b/includes/discount-actions.php
@@ -76,7 +76,7 @@ function edd_dcg_create_discount_codes( $data ) {
 
 	// Check number of codes is number and greater than 0
 	if ( floor( $posted['number-codes'] ) != $posted['number-codes'] || $posted['number-codes'] <= 0 ) {
-		return new WP_Error( 'invalid_number_codes', __( 'The supplied number of codes is invalid. Please enter an integer creater than zero.', 'edd_dcg' ) );
+		return new WP_Error( 'invalid_number_codes', __( 'The supplied number of codes is invalid. Please enter an integer greater than zero.', 'edd_dcg' ) );
 	}
 
 	$code = $posted;

--- a/includes/discount-actions.php
+++ b/includes/discount-actions.php
@@ -24,10 +24,10 @@ function edd_dcg_add_discount( $data ) {
 
 	$result = edd_dcg_create_discount_codes( $data );
 
-	if ( true === $result ) {
+	if ( is_numeric( $result ) ) {
 		$args = array(
 			'edd-message' => 'discounts_added',
-			'edd-number'  => isset( $data['number-codes'] ) ? urlencode( $data['number-codes'] ) : 0,
+			'edd-number'  => urlencode( $result ),
 		);
 	} else {
 		$args = array(
@@ -50,7 +50,7 @@ add_action( 'edd_add_discount', 'edd_dcg_add_discount' );
  *
  * @param array $data
  *
- * @return true|WP_Error
+ * @return int|WP_Error Number of discount codes created on success, `WP_Error` on failure.
  */
 function edd_dcg_create_discount_codes( $data ) {
 	// Setup the discount code details
@@ -104,8 +104,8 @@ function edd_dcg_create_discount_codes( $data ) {
 	$result = true;
 
 	// Loop through and generate code, check code doesnt exist _edd_discount_code
-	for ( $i = 1; $i <= $posted['number-codes']; $i++ ) {
-		$code['name']   = $posted['name'] . '-' . $i;
+	for ( $i = 0; $i < $posted['number-codes']; $i++ ) {
+		$code['name']   = $posted['name'] . '-' . ( $i + 1 );
 		$code['code']   = edd_dcg_create_code( $posted['code-type'], $code_limit );
 		$code['status'] = 'active';
 		if ( function_exists( 'edd_add_adjustment' ) ) {
@@ -123,7 +123,7 @@ function edd_dcg_create_discount_codes( $data ) {
 		return $result;
 	}
 
-	return true;
+	return $i;
 }
 
 function edd_dcg_create_code( $type, $limit ) {


### PR DESCRIPTION
Closes #3 

Changes:

1. Added a WP-CLI command `wp edd generate:discounts`
2. Introduced a new function called `edd_dcg_create_discount_codes()`. This is so that both the admin UI and CLI can use that same function for creating all the discount codes.

`wp help edd generate:discounts` should show you information about the new command, including a list of all possible options.

To test, run the command with a few different settings. Example:

`wp edd generate:discounts 35_off_some --amount=35 --amount-type="flat" --number=2 --products="367,337"`

Then check the codes in the admin area to make sure the settings match up.