### PR TITLE
#11 Default end time

### DIFF
--- a/includes/discount-actions.php
+++ b/includes/discount-actions.php
@@ -95,7 +95,7 @@ function edd_dcg_create_discount_codes( $data ) {
 	if ( function_exists( 'edd_add_adjustment' ) ) {
 		$code['scope'] = ! empty( $data['not_global'] ) ? 'not_global' : 'global';
 		if ( isset( $code['expiration'] ) ) {
-			$code['expiration'] = date( 'Y-m-d', strtotime( $code['expiration'] ) . '23:59:59' );
+			$code['expiration'] = date( 'Y-m-d 23:59:59', strtotime( $code['expiration'] ) );
 		}
 		foreach ( $fields_to_convert as $edd2x => $edd30 ) {
 			$code[ $edd30 ] = ! empty( $code[ $edd2x ] ) ? $code[ $edd2x ] : '';

--- a/includes/discount-actions.php
+++ b/includes/discount-actions.php
@@ -94,6 +94,9 @@ function edd_dcg_create_discount_codes( $data ) {
 	);
 	if ( function_exists( 'edd_add_adjustment' ) ) {
 		$code['scope'] = ! empty( $data['not_global'] ) ? 'not_global' : 'global';
+		if ( isset( $code['expiration'] ) ) {
+			$code['expiration'] = date( 'Y-m-d 23:59:59', $code['expiration'] );
+		}
 		foreach ( $fields_to_convert as $edd2x => $edd30 ) {
 			$code[ $edd30 ] = ! empty( $code[ $edd2x ] ) ? $code[ $edd2x ] : '';
 			unset( $code[ $edd2x ] );

--- a/includes/discount-actions.php
+++ b/includes/discount-actions.php
@@ -95,7 +95,7 @@ function edd_dcg_create_discount_codes( $data ) {
 	if ( function_exists( 'edd_add_adjustment' ) ) {
 		$code['scope'] = ! empty( $data['not_global'] ) ? 'not_global' : 'global';
 		if ( isset( $code['expiration'] ) ) {
-			$code['expiration'] = date( 'Y-m-d 23:59:59', $code['expiration'] );
+			$code['expiration'] = date( 'Y-m-d', strtotime( $code['expiration'] ) . '23:59:59' );
 		}
 		foreach ( $fields_to_convert as $edd2x => $edd30 ) {
 			$code[ $edd30 ] = ! empty( $code[ $edd2x ] ) ? $code[ $edd2x ] : '';

--- a/includes/discount-actions.php
+++ b/includes/discount-actions.php
@@ -94,9 +94,16 @@ function edd_dcg_create_discount_codes( $data ) {
 	);
 	if ( function_exists( 'edd_add_adjustment' ) ) {
 		$code['scope'] = ! empty( $data['not_global'] ) ? 'not_global' : 'global';
+
 		if ( isset( $code['expiration'] ) ) {
-			$code['expiration'] = date( 'Y-m-d 23:59:59', strtotime( $code['expiration'] ) );
+			$end_date      = sanitize_text_field( $code['expiration'] );
+			$end_date_time = '23:59:00';
+
+			// The end date is entered in the user's WP timezone. We need to convert it to UTC prior to saving now.
+			$date               = edd_get_utc_equivalent_date( EDD()->utils->date( $end_date . ' ' . $end_date_time, edd_get_timezone_id(), false ) );
+			$code['expiration'] = $date->format( 'Y-m-d H:i:s' );
 		}
+
 		foreach ( $fields_to_convert as $edd2x => $edd30 ) {
 			$code[ $edd30 ] = ! empty( $code[ $edd2x ] ) ? $code[ $edd2x ] : '';
 			unset( $code[ $edd2x ] );


### PR DESCRIPTION
Fixes #11 

Proposed changes:
- If in 3.0, format end time of discount to include default end time (23:59)

There are a lot of different ways to format the date. I chose to model this after [this function](https://github.com/easydigitaldownloads/easy-digital-downloads/blob/f7e238c466a629f723d8efd2fa311fbb41db71fc/includes/discount-functions.php#L403-L406) in discount-functions, but I am open to suggestions.